### PR TITLE
(geojson-utils) Changed BaseX GeoJson types, renamed GJ.Object

### DIFF
--- a/packages/envisim-geojson-utils/src/geojson/gcs/AbstractGeometryCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/gcs/AbstractGeometryCollection.ts
@@ -9,7 +9,7 @@ import type {AreaObject, LineObject, PointObject} from '../objects/index.js';
 
 export abstract class AbstractGeometryCollection<
   T extends AreaObject | LineObject | PointObject,
-  G extends GJ.Object,
+  G extends GJ.SingleTypeObject,
 > extends GeoJsonObject<'GeometryCollection'> {
   geometries!: T[];
 

--- a/packages/envisim-geojson-utils/src/geojson/objects/AbstractAreaObject.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/AbstractAreaObject.ts
@@ -1,9 +1,9 @@
 import type * as GJ from '../../types/geojson.js';
-import {AbstractObject} from './AbstractObject.js';
+import {AbstractSingleTypeObject} from './AbstractSingleTypeObject.js';
 
 export abstract class AbstractAreaObject<
   T extends GJ.AreaObject,
-> extends AbstractObject<T> {
+> extends AbstractSingleTypeObject<T> {
   constructor(obj: GJ.AreaObject, shallow: boolean = true) {
     super(obj, shallow);
   }

--- a/packages/envisim-geojson-utils/src/geojson/objects/AbstractLineObject.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/AbstractLineObject.ts
@@ -1,9 +1,9 @@
 import type * as GJ from '../../types/geojson.js';
-import {AbstractObject} from './AbstractObject.js';
+import {AbstractSingleTypeObject} from './AbstractSingleTypeObject.js';
 
 export abstract class AbstractLineObject<
   T extends GJ.LineObject,
-> extends AbstractObject<T> {
+> extends AbstractSingleTypeObject<T> {
   constructor(obj: GJ.LineObject, shallow: boolean = true) {
     super(obj, shallow);
   }

--- a/packages/envisim-geojson-utils/src/geojson/objects/AbstractPointObject.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/AbstractPointObject.ts
@@ -1,9 +1,9 @@
 import type * as GJ from '../../types/geojson.js';
-import {AbstractObject} from './AbstractObject.js';
+import {AbstractSingleTypeObject} from './AbstractSingleTypeObject.js';
 
 export abstract class AbstractPointObject<
   T extends GJ.PointObject,
-> extends AbstractObject<T> {
+> extends AbstractSingleTypeObject<T> {
   constructor(obj: GJ.PointObject, shallow: boolean = true) {
     super(obj, shallow);
   }

--- a/packages/envisim-geojson-utils/src/geojson/objects/AbstractSingleTypeObject.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/AbstractSingleTypeObject.ts
@@ -3,12 +3,12 @@ import {copy} from '@envisim/utils';
 import type * as GJ from '../../types/geojson.js';
 import {GeoJsonObject, type GeomEachCallback} from '../base/index.js';
 
-export abstract class AbstractObject<T extends GJ.Object> extends GeoJsonObject<
-  T['type']
-> {
+export abstract class AbstractSingleTypeObject<
+  T extends GJ.SingleTypeObject,
+> extends GeoJsonObject<T['type']> {
   coordinates: T['coordinates'];
 
-  constructor(obj: GJ.Object, shallow: boolean = true) {
+  constructor(obj: GJ.SingleTypeObject, shallow: boolean = true) {
     super(obj, shallow);
 
     if (shallow === true) {

--- a/packages/envisim-geojson-utils/src/types/geojson.ts
+++ b/packages/envisim-geojson-utils/src/types/geojson.ts
@@ -43,20 +43,21 @@ export interface MultiCircle extends BaseObject<'MultiPoint', Position[]> {
 }
 export type AreaObject = Polygon | MultiPolygon | Circle | MultiCircle;
 
-export type Object = PointObject | LineObject | AreaObject;
+export type SingleTypeObject = PointObject | LineObject | AreaObject;
 
 // GEOMETRY COLLECTIONS
-export interface BaseGeometryCollection<G extends BaseGeometry = Object>
+export interface BaseGeometryCollection<G extends BaseGeometry = BaseGeometry>
   extends GeoJsonObject<'GeometryCollection'> {
   geometries: G[];
 }
-export type GeometryCollection<O extends Object> = BaseGeometryCollection<O>;
+export type GeometryCollection<O extends SingleTypeObject> =
+  BaseGeometryCollection<O>;
 export type PointGeometryCollection = GeometryCollection<PointObject>;
 export type LineGeometryCollection = GeometryCollection<LineObject>;
 export type AreaGeometryCollection = GeometryCollection<AreaObject>;
 
 // GEOMETRIES
-export type BaseGeometry = Object | BaseGeometryCollection;
+export type BaseGeometry = SingleTypeObject | BaseGeometryCollection;
 export type PointGeometry = PointObject | PointGeometryCollection;
 export type LineGeometry = LineObject | LineGeometryCollection;
 export type AreaGeometry = AreaObject | AreaGeometryCollection;
@@ -64,26 +65,24 @@ export type Geometry = PointGeometry | LineGeometry | AreaGeometry;
 
 // FEATURES
 export interface BaseFeature<
-  G extends BaseGeometry | null = Geometry,
-  P = number,
+  G extends BaseGeometry | null = BaseGeometry,
+  P = any,
 > extends GeoJsonObject<'Feature'> {
   geometry: G;
   properties: FeatureProperties<P> | null;
 }
-export interface Feature<G extends Geometry = Geometry>
-  extends BaseFeature<G, number> {}
-export interface PointFeature extends Feature<PointGeometry> {}
-export interface LineFeature extends Feature<LineGeometry> {}
-export interface AreaFeature extends Feature<AreaGeometry> {}
+export type Feature<G extends Geometry = Geometry> = BaseFeature<G, number>;
+export type PointFeature = Feature<PointGeometry>;
+export type LineFeature = Feature<LineGeometry>;
+export type AreaFeature = Feature<AreaGeometry>;
 
 // FEATURE COLLECTIONS
-export interface BaseFeatureCollection<F extends BaseFeature>
+export interface BaseFeatureCollection<F extends BaseFeature = BaseFeature>
   extends GeoJsonObject<'FeatureCollection'> {
   features: F[];
 }
-export interface FeatureCollection<F extends Feature = Feature>
-  extends BaseFeatureCollection<F> {}
-export interface PointFeatureCollection
-  extends FeatureCollection<PointFeature> {}
-export interface LineFeatureCollection extends FeatureCollection<LineFeature> {}
-export interface AreaFeatureCollection extends FeatureCollection<AreaFeature> {}
+export type FeatureCollection<F extends Feature = Feature> =
+  BaseFeatureCollection<F>;
+export type PointFeatureCollection = FeatureCollection<PointFeature>;
+export type LineFeatureCollection = FeatureCollection<LineFeature>;
+export type AreaFeatureCollection = FeatureCollection<AreaFeature>;


### PR DESCRIPTION
Implemented the changes proposed in #30. Also renamed the, in hindsight, rather stupidly named `Object` GeoJSON Single Type Geometry Object to SingleTypeObject, as, one might now, `Object` exists in JS.