### PR TITLE
(geojson-utils) Changed assert-methods to return asserts

### DIFF
--- a/packages/envisim-geojson-utils/src/geojson/collections/ClassAreaCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/collections/ClassAreaCollection.ts
@@ -14,9 +14,11 @@ export class AreaCollection
     return obj instanceof AreaCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is AreaCollection {
-    if (obj instanceof AreaCollection) return true;
-    throw new TypeError(msg ?? 'Expected AreaCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected AreaCollection',
+  ): asserts obj is AreaCollection {
+    if (!(obj instanceof AreaCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/collections/ClassLineCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/collections/ClassLineCollection.ts
@@ -14,9 +14,11 @@ export class LineCollection
     return obj instanceof LineCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is LineCollection {
-    if (obj instanceof LineCollection) return true;
-    throw new TypeError(msg ?? 'Expected LineCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected LineCollection',
+  ): asserts obj is LineCollection {
+    if (!(obj instanceof LineCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/collections/ClassPointCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/collections/ClassPointCollection.ts
@@ -14,9 +14,11 @@ export class PointCollection
     return obj instanceof PointCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is PointCollection {
-    if (obj instanceof PointCollection) return true;
-    throw new TypeError(msg ?? 'Expected PointCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected PointCollection',
+  ): asserts obj is PointCollection {
+    if (!(obj instanceof PointCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/features/ClassAreaFeature.ts
+++ b/packages/envisim-geojson-utils/src/geojson/features/ClassAreaFeature.ts
@@ -13,9 +13,11 @@ export class AreaFeature
     return obj instanceof AreaFeature;
   }
 
-  static assert(obj: unknown, msg?: string): obj is AreaFeature {
-    if (obj instanceof AreaFeature) return true;
-    throw new TypeError(msg ?? 'Expected AreaFeature');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected AreaFeature',
+  ): asserts obj is AreaFeature {
+    if (!(obj instanceof AreaFeature)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/features/ClassLineFeature.ts
+++ b/packages/envisim-geojson-utils/src/geojson/features/ClassLineFeature.ts
@@ -13,9 +13,11 @@ export class LineFeature
     return obj instanceof LineFeature;
   }
 
-  static assert(obj: unknown, msg?: string): obj is LineFeature {
-    if (obj instanceof LineFeature) return true;
-    throw new TypeError(msg ?? 'Expected LineFeature');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected LineFeature',
+  ): asserts obj is LineFeature {
+    if (!(obj instanceof LineFeature)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/features/ClassPointFeature.ts
+++ b/packages/envisim-geojson-utils/src/geojson/features/ClassPointFeature.ts
@@ -13,9 +13,11 @@ export class PointFeature
     return obj instanceof PointFeature;
   }
 
-  static assert(obj: unknown, msg?: string): obj is PointFeature {
-    if (obj instanceof PointFeature) return true;
-    throw new TypeError(msg ?? 'Expected PointFeature');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected PointFeature',
+  ): asserts obj is PointFeature {
+    if (!(obj instanceof PointFeature)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/gcs/ClassAreaGeometryCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/gcs/ClassAreaGeometryCollection.ts
@@ -14,9 +14,11 @@ export class AreaGeometryCollection
     return obj instanceof AreaGeometryCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is AreaGeometryCollection {
-    if (obj instanceof AreaGeometryCollection) return true;
-    throw new TypeError(msg ?? 'Expected AreaGeometryCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected AreaGeometryCollection',
+  ): asserts obj is AreaGeometryCollection {
+    if (!(obj instanceof AreaGeometryCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/gcs/ClassLineGeometryCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/gcs/ClassLineGeometryCollection.ts
@@ -14,9 +14,11 @@ export class LineGeometryCollection
     return obj instanceof LineGeometryCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is LineGeometryCollection {
-    if (obj instanceof LineGeometryCollection) return true;
-    throw new TypeError(msg ?? 'Expected LineGeometryCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected LineGeometryCollection',
+  ): asserts obj is LineGeometryCollection {
+    if (!(obj instanceof LineGeometryCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/gcs/ClassPointGeometryCollection.ts
+++ b/packages/envisim-geojson-utils/src/geojson/gcs/ClassPointGeometryCollection.ts
@@ -14,9 +14,11 @@ export class PointGeometryCollection
     return obj instanceof PointGeometryCollection;
   }
 
-  static assert(obj: unknown, msg?: string): obj is PointGeometryCollection {
-    if (obj instanceof PointGeometryCollection) return true;
-    throw new TypeError(msg ?? 'Expected PointGeometryCollection');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected PointGeometryCollection',
+  ): asserts obj is PointGeometryCollection {
+    if (!(obj instanceof PointGeometryCollection)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassCircle.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassCircle.ts
@@ -12,9 +12,11 @@ export class Circle extends AbstractAreaObject<GJ.Circle> implements GJ.Circle {
     return obj instanceof Circle;
   }
 
-  static assert(obj: unknown, msg?: string): obj is Circle {
-    if (obj instanceof Circle) return true;
-    throw new TypeError(msg ?? 'Expected Circle');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected Circle',
+  ): asserts obj is Circle {
+    if (!(obj instanceof Circle)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassLineString.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassLineString.ts
@@ -14,9 +14,11 @@ export class LineString
     return obj instanceof LineString;
   }
 
-  static assert(obj: unknown, msg?: string): obj is LineString {
-    if (obj instanceof LineString) return true;
-    throw new TypeError(msg ?? 'Expected LineString');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected LineString',
+  ): asserts obj is LineString {
+    if (!(obj instanceof LineString)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiCircle.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiCircle.ts
@@ -16,9 +16,11 @@ export class MultiCircle
     return obj instanceof MultiCircle;
   }
 
-  static assert(obj: unknown, msg?: string): obj is MultiCircle {
-    if (obj instanceof MultiCircle) return true;
-    throw new TypeError(msg ?? 'Expected MultiCircle');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected MultiCircle',
+  ): asserts obj is MultiCircle {
+    if (!(obj instanceof MultiCircle)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiLineString.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiLineString.ts
@@ -17,9 +17,11 @@ export class MultiLineString
     return obj instanceof MultiLineString;
   }
 
-  static assert(obj: unknown, msg?: string): obj is MultiLineString {
-    if (obj instanceof MultiLineString) return true;
-    throw new TypeError(msg ?? 'Expected MultiLineString');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected MultiLineString',
+  ): asserts obj is MultiLineString {
+    if (!(obj instanceof MultiLineString)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiPoint.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiPoint.ts
@@ -13,9 +13,11 @@ export class MultiPoint
     return obj instanceof MultiPoint;
   }
 
-  static assert(obj: unknown, msg?: string): obj is MultiPoint {
-    if (obj instanceof MultiPoint) return true;
-    throw new TypeError(msg ?? 'Expected MultiPoint');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected MultiPoint',
+  ): asserts obj is MultiPoint {
+    if (!(obj instanceof MultiPoint)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiPolygon.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassMultiPolygon.ts
@@ -19,9 +19,11 @@ export class MultiPolygon
     return obj instanceof MultiPolygon;
   }
 
-  static assert(obj: unknown, msg?: string): obj is MultiPolygon {
-    if (obj instanceof MultiPolygon) return true;
-    throw new TypeError(msg ?? 'Expected MultiPolygon');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected MultiPolygon',
+  ): asserts obj is MultiPolygon {
+    if (!(obj instanceof MultiPolygon)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassPoint.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassPoint.ts
@@ -8,9 +8,11 @@ export class Point extends AbstractPointObject<GJ.Point> implements GJ.Point {
     return obj instanceof Point;
   }
 
-  static assert(obj: unknown, msg?: string): obj is Point {
-    if (obj instanceof Point) return true;
-    throw new TypeError(msg ?? 'Expected Point');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected Point',
+  ): asserts obj is Point {
+    if (!(obj instanceof Point)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-geojson-utils/src/geojson/objects/ClassPolygon.ts
+++ b/packages/envisim-geojson-utils/src/geojson/objects/ClassPolygon.ts
@@ -16,9 +16,11 @@ export class Polygon
     return obj instanceof Polygon;
   }
 
-  static assert(obj: unknown, msg?: string): obj is Polygon {
-    if (obj instanceof Polygon) return true;
-    throw new TypeError(msg ?? 'Expected Polygon');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected Polygon',
+  ): asserts obj is Polygon {
+    if (!(obj instanceof Polygon)) throw new TypeError(msg);
   }
 
   static create(

--- a/packages/envisim-matrix/src/base/BaseMatrix.ts
+++ b/packages/envisim-matrix/src/base/BaseMatrix.ts
@@ -51,15 +51,16 @@ export abstract class BaseMatrix {
   }
 
   /**
-   * @param msg message to pass, defaults to `"Expected BaseMatrix"`
-   * @returns `true` if `obj` is BaseMatrix
+   * @param msg message to pass
    * @throws TypeError if `obj` is not BaseMatrix
    * @group Static methods
    * @group Property methods
    */
-  static assert(obj: unknown, msg?: string): obj is BaseMatrix {
-    if (obj instanceof BaseMatrix) return true;
-    throw new TypeError(msg ?? 'Expected BaseMatrix');
+  static assert(
+    obj: unknown,
+    msg: string = 'Expected BaseMatrix',
+  ): asserts obj is BaseMatrix {
+    if (!(obj instanceof BaseMatrix)) throw new TypeError(msg);
   }
 
   /** @internal */

--- a/packages/envisim-matrix/src/base/BaseVector.ts
+++ b/packages/envisim-matrix/src/base/BaseVector.ts
@@ -15,15 +15,16 @@ export abstract class BaseVector extends BaseMatrix {
   }
 
   /**
-   * @param msg message to pass, defaults to `"Expected BaseVector"`
-   * @returns `true` if `obj` is BaseVector
+   * @param msg message to pass
    * @throws TypeError if `obj` is not BaseVector
    * @group Static methods
    * @group Property methods
    */
-  static override assert(obj: unknown, msg?: string): obj is BaseVector {
-    if (obj instanceof BaseVector) return true;
-    throw new TypeError(msg ?? 'Expected BaseVector');
+  static override assert(
+    obj: unknown,
+    msg: string = 'Expected BaseVector',
+  ): asserts obj is BaseVector {
+    if (!(obj instanceof BaseVector)) throw new TypeError(msg);
   }
 
   constructor(arr: number[], nrow: number, ncol: number) {

--- a/packages/envisim-matrix/src/base/ColumnVector.ts
+++ b/packages/envisim-matrix/src/base/ColumnVector.ts
@@ -15,15 +15,16 @@ export class ColumnVector extends BaseVector {
   }
 
   /**
-   * @param msg message to pass, defaults to `"Expected ColumnVector"`
-   * @returns `true` if `obj` is ColumnVector
+   * @param msg message to pass
    * @throws TypeError if `obj` is not ColumnVector
    * @group Static methods
    * @group Property methods
    */
-  static override assert(obj: unknown, msg?: string): obj is ColumnVector {
-    if (obj instanceof ColumnVector) return true;
-    throw new TypeError(msg ?? 'Expected ColumnVector');
+  static override assert(
+    obj: unknown,
+    msg: string = 'Expected ColumnVector',
+  ): asserts obj is ColumnVector {
+    if (!(obj instanceof ColumnVector)) throw new TypeError(msg);
   }
 
   /**

--- a/packages/envisim-matrix/src/base/RowVector.ts
+++ b/packages/envisim-matrix/src/base/RowVector.ts
@@ -13,15 +13,16 @@ export class RowVector extends BaseVector {
   }
 
   /**
-   * @param msg message to pass, defaults to `"Expected RowVector"`
-   * @returns `true` if `obj` is RowVector
+   * @param msg message to pass
    * @throws TypeError if `obj` is not RowVector
    * @group Static methods
    * @group Property methods
    */
-  static override assert(obj: unknown, msg?: string): obj is RowVector {
-    if (obj instanceof RowVector) return true;
-    throw new TypeError(msg ?? 'Expected RowVector');
+  static override assert(
+    obj: unknown,
+    msg: string = 'Expected RowVector',
+  ): asserts obj is RowVector {
+    if (!(obj instanceof RowVector)) throw new TypeError(msg);
   }
 
   /**


### PR DESCRIPTION
It was weird that the assert-methods was not returning the `asserts` type, but now they do.