### PR TITLE
(geojson-utils) Fixed bug in isMultiCircle

### DIFF
--- a/packages/envisim-geojson-utils/src/types/type-guards.ts
+++ b/packages/envisim-geojson-utils/src/types/type-guards.ts
@@ -23,7 +23,7 @@ export function isMultiCircle(
   checkPositiveRadius: boolean = false,
 ): obj is GJ.MultiCircle {
   return (
-    !Object.hasOwn(obj, 'radius') &&
+    Object.hasOwn(obj, 'radius') &&
     (!checkPositiveRadius || (obj as GJ.MultiCircle).radius > 0.0)
   );
 }


### PR DESCRIPTION
The `isMultiCircle` type guard assured that the object did not have a `radius` property, when in fact, it needs one to be a MultiCircle.