### PR TITLE
(geojson-utils) bug: incorrectly deciding intersect with downward segment

### DIFF
--- a/packages/envisim-geojson-utils/src/utils/class-segment.ts
+++ b/packages/envisim-geojson-utils/src/utils/class-segment.ts
@@ -126,7 +126,7 @@ export class Segment {
       if (point[1] < this.p1[1] || this.p2[1] <= point[1]) return null; // (1)
     } else {
       // Downward segment
-      if (point[1] <= this.p1[1] || this.p2[1] < point[1]) return null; // (2)
+      if (point[1] < this.p2[1] || this.p1[1] <= point[1]) return null; // (2)
     }
 
     const xdiff = point[0] - this.p1[0];

--- a/packages/envisim-geojson-utils/tests/intersect/intersect-area-area.test.ts
+++ b/packages/envisim-geojson-utils/tests/intersect/intersect-area-area.test.ts
@@ -149,3 +149,27 @@ test('intersect converted circle-polygon', () => {
   const int1 = intersectAreaAreaGeometries(polygon, polycircle);
   expect(int1).not.toBeNull();
 });
+
+test('non-overlapping', () => {
+  const poly1 = Polygon.create([
+    [
+      [20.382250571191626, 63.79941345753493],
+      [20.38253248161436, 63.799284398430416],
+      [20.382824408311265, 63.79940902934919],
+      [20.38254249797854, 63.79953808902122],
+      [20.382250571191626, 63.79941345753493],
+    ],
+  ]);
+  const poly2 = Polygon.create([
+    [
+      [20.383759, 63.800804],
+      [20.380669, 63.800037],
+      [20.383523, 63.799279],
+      [20.386033, 63.800188],
+      [20.383759, 63.800804],
+    ],
+  ]);
+
+  const int1 = intersectAreaAreaGeometries(poly1, poly2);
+  expect(int1).toBeNull();
+});


### PR DESCRIPTION
When checking the intersect between a polygon and the rightward going ray emerging from a point, the algorithm incorrectly decided whether or not the ray intersected a downward facing segment.