### PR TITLE
(geojson-utils, geosampling) use model geometry instead of feature

### DIFF
--- a/packages/envisim-geojson-utils/src/utils/antimeridian.ts
+++ b/packages/envisim-geojson-utils/src/utils/antimeridian.ts
@@ -85,7 +85,7 @@ function cutLineStringCoords(ls: GJ.Position[]): GJ.Position[][] {
  * @param g the LineGeometry to cut
  * @returns the cut LineGeometry
  */
-export function cutLineGeometry(g: GJ.LineGeometry): GJ.LineGeometry {
+export function cutLineGeometry(g: GJ.LineObject): GJ.LineObject {
   const gjType = g.type;
   let mls: GJ.Position[][] = [];
   let imls: GJ.Position[][] = [];
@@ -101,24 +101,6 @@ export function cutLineGeometry(g: GJ.LineGeometry): GJ.LineGeometry {
         imls.forEach((ls) => mls.push(ls));
       });
       break;
-
-    case 'GeometryCollection':
-      g.geometries.forEach((geom) => {
-        switch (geom.type) {
-          case 'LineString':
-            imls = cutLineStringCoords(geom.coordinates);
-            imls.forEach((ls) => mls.push(ls));
-            break;
-          case 'MultiLineString':
-            geom.coordinates.forEach((ls) => {
-              imls = cutLineStringCoords(ls);
-              imls.forEach((ls) => mls.push(ls));
-            });
-            break;
-        }
-      });
-      break;
-
     default:
       throw new Error('Invalid type');
   }
@@ -201,7 +183,7 @@ function cutPolygonCoords(pol: GJ.Position[][]): GJ.Position[][][] {
  * @param g the AreaGeometry to cut
  * @returns the cut AreaGeometry
  */
-export function cutAreaGeometry(g: GJ.AreaGeometry): GJ.AreaGeometry {
+export function cutAreaGeometry(g: GJ.AreaObject): GJ.AreaObject {
   const geom = copy(g);
   const type = geom.type;
   let mpc: GJ.Position[][][] = [];
@@ -223,11 +205,6 @@ export function cutAreaGeometry(g: GJ.AreaGeometry): GJ.AreaGeometry {
         impc.forEach((p) => mpc.push(p));
       });
       return {type: 'MultiPolygon', coordinates: mpc};
-    case 'GeometryCollection':
-      for (let i = 0; i < geom.geometries.length; i++) {
-        geom.geometries[i] = cutAreaGeometry(geom.geometries[i]) as GJ.AreaObject;
-      }
-      return geom;
     default:
       throw new Error('Invalid type');
   }

--- a/packages/envisim-geosampling/src/index.ts
+++ b/packages/envisim-geosampling/src/index.ts
@@ -23,37 +23,30 @@ export {
 export {sampleFinite, sampleFiniteOptionsCheck} from './sample-finite/index.js';
 
 // Stratified
-export {
-  sampleStratified,
-  sampleStratifiedOptionsCheck,
-} from './sample-stratified.js';
+export {sampleStratified, sampleStratifiedOptionsCheck} from './sample-stratified.js';
 
-// Model features/tracts
+// Model geometries/tracts
 export {
-  radiusOfModelFeature,
-  sizeOfModelFeature,
-  straightLineFeature,
-  ellLineFeature,
-  rectangularLineFeature,
-  squareLineFeature,
-  regularPolygonLineFeature,
-  regularPolygonPointFeature,
-  circleLineFeature,
-  circleAreaFeature,
-  squareCircleAreaFeature,
-  regularPolygonAreaFeature,
-  rectangularAreaFeature,
-  squareAreaFeature,
-  pointFeature,
-  squarePointFeature,
-} from './model-feature.js';
+  radiusOfModelGeometry,
+  sizeOfModelGeometry,
+  straightLineGeometry,
+  ellLineGeometry,
+  rectangularLineGeometry,
+  squareLineGeometry,
+  regularPolygonLineGeometry,
+  regularPolygonPointGeometry,
+  circleLineGeometry,
+  circleAreaGeometry,
+  squareCircleAreaGeometry,
+  regularPolygonAreaGeometry,
+  rectangularAreaGeometry,
+  squareAreaGeometry,
+  pointGeometry,
+  squarePointGeometry,
+} from './model-geometry.js';
 
 // Collection from layers
-export {
-  collectProperties,
-  collectPropertyRecord,
-  collectIntersects,
-} from './collect/index.js';
+export {collectProperties, collectPropertyRecord, collectIntersects} from './collect/index.js';
 
 // Point processes
 export {

--- a/packages/envisim-geosampling/src/sample-continuous/features-on-areas.ts
+++ b/packages/envisim-geosampling/src/sample-continuous/features-on-areas.ts
@@ -5,10 +5,10 @@ import {
   GeometricPrimitive,
   type LineObject,
   type PointObject,
-  getFeaturePrimitive,
+  getGeometryPrimitive,
 } from '@envisim/geojson-utils';
 
-import {placeModelFeature, radiusOfModelFeature, sizeOfModelFeature} from '../model-feature.js';
+import {placeModelGeometry, radiusOfModelGeometry, sizeOfModelGeometry} from '../model-geometry.js';
 import {
   intersectAreaSampleAreaFrame,
   intersectLineSampleAreaFrame,
@@ -29,15 +29,15 @@ import {samplePointsOnAreas} from './points-on-areas.js';
  */
 function sampleFeaturesOnAreas(
   collection: FeatureCollection<AreaObject>,
-  opts: SampleFeatureOptions<GJ.PointFeature>,
+  opts: SampleFeatureOptions<GJ.PointObject>,
 ): FeatureCollection<PointObject>;
 function sampleFeaturesOnAreas(
   collection: FeatureCollection<AreaObject>,
-  opts: SampleFeatureOptions<GJ.LineFeature>,
+  opts: SampleFeatureOptions<GJ.LineObject>,
 ): FeatureCollection<LineObject>;
 function sampleFeaturesOnAreas(
   collection: FeatureCollection<AreaObject>,
-  opts: SampleFeatureOptions<GJ.AreaFeature>,
+  opts: SampleFeatureOptions<GJ.AreaObject>,
 ): FeatureCollection<AreaObject>;
 function sampleFeaturesOnAreas(
   collection: FeatureCollection<AreaObject>,
@@ -46,36 +46,40 @@ function sampleFeaturesOnAreas(
     pointsPerCircle = SAMPLE_FEATURE_OPTIONS.pointsPerCircle,
     pointSelection,
     sampleSize,
-    modelFeature,
-    rotation = SAMPLE_FEATURE_OPTIONS.rotation,
-    randomRotation = SAMPLE_FEATURE_OPTIONS.randomRotation,
+    modelGeometry,
+    rotationOfGeometry = SAMPLE_FEATURE_OPTIONS.rotationOfGeometry,
+    randomRotationOfGeometry = SAMPLE_FEATURE_OPTIONS.randomRotationOfGeometry,
     ratio = SAMPLE_FEATURE_OPTIONS.ratio,
-  }: SampleFeatureOptions<GJ.AreaFeature | GJ.LineFeature | GJ.PointFeature>,
+    rotationOfGrid = SAMPLE_FEATURE_OPTIONS.rotationOfGrid,
+    randomRotationOfGrid = SAMPLE_FEATURE_OPTIONS.randomRotationOfGrid,
+  }: SampleFeatureOptions<GJ.AreaObject | GJ.LineObject | GJ.PointObject>,
 ): FeatureCollection<AreaObject> | FeatureCollection<LineObject> | FeatureCollection<PointObject> {
   const optionsError = sampleFeatureOptionsCheck(collection, {
     rand,
     pointsPerCircle,
     pointSelection,
     sampleSize,
-    modelFeature,
-    rotation,
-    randomRotation,
+    modelGeometry,
+    rotationOfGeometry,
+    randomRotationOfGeometry,
     ratio,
+    rotationOfGrid,
+    randomRotationOfGrid,
   });
   if (optionsError !== 0) {
     throw new RangeError(`sampleFeaturesOnAreas error: ${optionsError}`);
   }
 
-  const tractType = getFeaturePrimitive(modelFeature);
+  const tractType = getGeometryPrimitive(modelGeometry);
 
   // Force randomRotation for type line!
   if (tractType === GeometricPrimitive.LINE) {
-    randomRotation = true;
+    randomRotationOfGeometry = true;
   }
 
   // Compute radius and size of the model tract.
-  const radius = radiusOfModelFeature(modelFeature);
-  const sizeOfTract = sizeOfModelFeature(modelFeature);
+  const radius = radiusOfModelGeometry(modelGeometry);
+  const sizeOfTract = sizeOfModelGeometry(modelGeometry);
 
   // Select first a sample of points and use radius as buffer.
   const pointCollection = samplePointsOnAreas(collection, {
@@ -84,6 +88,8 @@ function sampleFeaturesOnAreas(
     buffer: radius,
     rand,
     ratio,
+    rotationOfGrid,
+    randomRotationOfGrid,
   });
 
   if (radius === 0) {
@@ -96,27 +102,28 @@ function sampleFeaturesOnAreas(
     case GeometricPrimitive.POINT: {
       const pointFeatures: GJ.PointFeature[] = [];
       pointCollection.forEach((feature) => {
-        const dw = (feature.properties?.['_designWeight'] ?? 1.0) as number;
-
-        let newFeature: GJ.PointFeature;
+        const dw = feature.getSpecialPropertyDesignWeight();
+        let newGeometry: GJ.PointObject;
 
         if (feature.geometry.type === 'Point') {
-          newFeature = placeModelFeature(
-            modelFeature as GJ.PointFeature,
+          newGeometry = placeModelGeometry(
+            modelGeometry as GJ.PointObject,
             feature.geometry.coordinates,
             {
-              rotation: rotation,
-              randomRotation: randomRotation,
+              rotation: rotationOfGeometry,
+              randomRotation: randomRotationOfGeometry,
               rand: rand,
               type: tractType,
               radius: radius,
             },
           );
-
-          if (newFeature.properties) {
-            newFeature.properties['_designWeight'] = dw / sizeOfTract;
-          }
-          pointFeatures.push(newFeature);
+          pointFeatures.push({
+            type: 'Feature',
+            geometry: newGeometry,
+            properties: {
+              _designWeight: dw / sizeOfTract,
+            },
+          });
         }
       });
 
@@ -129,29 +136,29 @@ function sampleFeaturesOnAreas(
     case GeometricPrimitive.LINE: {
       const lineFeatures: GJ.LineFeature[] = [];
       pointCollection.forEach((feature) => {
-        const dw = (feature.properties?.['_designWeight'] ?? 1.0) as number;
-
-        let newFeature: GJ.LineFeature;
+        const dw = feature.getSpecialPropertyDesignWeight();
+        let newGeometry: GJ.LineObject;
 
         if (feature.geometry.type === 'Point') {
-          newFeature = placeModelFeature(
-            modelFeature as GJ.LineFeature,
+          newGeometry = placeModelGeometry(
+            modelGeometry as GJ.LineObject,
             feature.geometry.coordinates,
             {
-              rotation: rotation,
-              randomRotation: randomRotation,
+              rotation: rotationOfGeometry,
+              randomRotation: randomRotationOfGeometry,
               rand: rand,
               type: tractType,
               radius: radius,
             },
           );
-          if (newFeature.properties) {
-            newFeature.properties['_designWeight'] = dw / sizeOfTract;
-            if (randomRotation) {
-              newFeature.properties['_randomRotation'] = 1;
-            }
-          }
-          lineFeatures.push(newFeature);
+          lineFeatures.push({
+            type: 'Feature',
+            geometry: newGeometry,
+            properties: {
+              _designWeight: dw / sizeOfTract,
+              _randomRotation: randomRotationOfGeometry ? 1 : 0,
+            },
+          });
         }
       });
 
@@ -163,29 +170,29 @@ function sampleFeaturesOnAreas(
     case GeometricPrimitive.AREA: {
       const areaFeatures: GJ.AreaFeature[] = [];
       pointCollection.forEach((feature) => {
-        let newFeature: GJ.AreaFeature;
+        const dw = feature.getSpecialPropertyDesignWeight();
+        let newGeometry: GJ.AreaObject;
 
         if (feature.geometry.type === 'Point') {
-          newFeature = placeModelFeature(
-            modelFeature as GJ.AreaFeature,
+          newGeometry = placeModelGeometry(
+            modelGeometry as GJ.AreaObject,
             feature.geometry.coordinates,
             {
-              rotation: rotation,
-              randomRotation: randomRotation,
+              rotation: rotationOfGeometry,
+              randomRotation: randomRotationOfGeometry,
               rand: rand,
               type: tractType,
               radius: radius,
             },
           );
-          if (newFeature.properties) {
-            newFeature.properties['_designWeight'] =
-              feature.getSpecialPropertyDesignWeight() / sizeOfTract;
-
-            if (randomRotation) {
-              newFeature.properties['_randomRotation'] = 1;
-            }
-          }
-          areaFeatures.push(newFeature);
+          areaFeatures.push({
+            type: 'Feature',
+            geometry: newGeometry,
+            properties: {
+              _designWeight: dw / sizeOfTract,
+              _randomRotation: randomRotationOfGeometry ? 1 : 0,
+            },
+          });
         }
       });
       return intersectAreaSampleAreaFrame(FeatureCollection.createArea(areaFeatures), collection, {

--- a/packages/envisim-geosampling/src/sample-continuous/options.ts
+++ b/packages/envisim-geosampling/src/sample-continuous/options.ts
@@ -74,11 +74,11 @@ export interface SamplePointOptions extends SampleBaseOptions {
   /**
    * Optional rotation
    */
-  rotation?: number;
+  rotationOfGrid?: number;
   /**
    * Optional random rotation
    */
-  randomRotation?: boolean;
+  randomRotationOfGrid?: boolean;
 }
 
 export const SAMPLE_POINT_OPTIONS: Readonly<Required<SamplePointOptions>> = {
@@ -87,8 +87,8 @@ export const SAMPLE_POINT_OPTIONS: Readonly<Required<SamplePointOptions>> = {
   sampleSize: 1,
   ratio: 1.0,
   buffer: 0.0,
-  rotation: 0.0,
-  randomRotation: false,
+  rotationOfGrid: 0.0,
+  randomRotationOfGrid: false,
 };
 
 /**
@@ -130,36 +130,48 @@ export function samplePointOptionsCheck<T extends AreaObject | LineObject | Poin
  * @see {@link SAMPLE_FEATURE_OPTIONS | default values}
  * @see {@link sampleFeatureOptionsCheck | error codes}
  */
-export interface SampleFeatureOptions<F extends GJ.PointFeature | GJ.LineFeature | GJ.AreaFeature>
+export interface SampleFeatureOptions<G extends GJ.PointObject | GJ.LineObject | GJ.AreaObject>
   extends SamplePointOptions {
   /**
    * A model feature of points or lines or areas to be placed on the selcted
    * points.
    */
-  modelFeature: F;
+  modelGeometry: G;
   /**
-   * Optional rotation angle in degrees to rotate the model feature.
+   * Optional rotation angle in degrees to rotate the model geometry.
    * @defaultValue `0.0`
    */
-  rotation?: number;
+  rotationOfGeometry?: number;
   /**
-   * If true, then the model feature will be randomly rotated. Forced random
-   * rotation is used for line features.
+   * If true, then the model geometry will be randomly rotated. Forced random
+   * rotation is used for line geometries.
    * @defaultValue `false`
    */
-  randomRotation?: boolean;
+  randomRotationOfGeometry?: boolean;
+  /**
+   * If true, then the grid will be rotated
+   * @defaultValue `0.0`
+   */
+  rotationOfGrid?: number;
+  /**
+   * If true, then the grid will be randomly rotated
+   * @defaultValue `false`
+   */
+  randomRotationOfGrid?: boolean;
 }
 
 export const SAMPLE_FEATURE_OPTIONS: Readonly<
   Required<
-    Omit<SampleFeatureOptions<GJ.PointFeature | GJ.LineFeature | GJ.AreaFeature>, 'modelFeature'>
+    Omit<SampleFeatureOptions<GJ.PointObject | GJ.LineObject | GJ.AreaObject>, 'modelGeometry'>
   >
 > = {
   ...SAMPLE_POINT_OPTIONS,
   pointSelection: 'independent',
   sampleSize: 1,
-  rotation: 0.0,
-  randomRotation: false,
+  rotationOfGeometry: 0.0,
+  randomRotationOfGeometry: false,
+  rotationOfGrid: 0.0,
+  randomRotationOfGrid: false,
 };
 
 /**
@@ -171,15 +183,15 @@ export const SAMPLE_FEATURE_OPTIONS: Readonly<
  */
 export function sampleFeatureOptionsCheck<
   T extends AreaObject | LineObject | PointObject,
-  F extends GJ.PointFeature | GJ.LineFeature | GJ.AreaFeature,
+  G extends GJ.PointObject | GJ.LineObject | GJ.AreaObject,
 >(
   collection: FeatureCollection<T>,
   {
-    // modelFeature,
+    // modelGeometry,
     // rotation,
     // randomRotation,
     ...options
-  }: SampleFeatureOptions<F>,
+  }: SampleFeatureOptions<G>,
 ): number {
   const pointCheck = samplePointOptionsCheck(collection, options);
   if (pointCheck !== 0) {

--- a/packages/envisim-geosampling/src/sample-continuous/points-on-areas.ts
+++ b/packages/envisim-geosampling/src/sample-continuous/points-on-areas.ts
@@ -42,8 +42,8 @@ export function samplePointsOnAreas(
     sampleSize,
     buffer = SAMPLE_POINT_OPTIONS.buffer,
     ratio = SAMPLE_POINT_OPTIONS.ratio,
-    rotation = SAMPLE_POINT_OPTIONS.rotation,
-    randomRotation = SAMPLE_POINT_OPTIONS.randomRotation,
+    rotationOfGrid = SAMPLE_POINT_OPTIONS.rotationOfGrid,
+    randomRotationOfGrid = SAMPLE_POINT_OPTIONS.randomRotationOfGrid,
   }: SamplePointOptions,
 ): FeatureCollection<Point> {
   const optionsError = samplePointOptionsCheck(collection, {
@@ -51,8 +51,8 @@ export function samplePointsOnAreas(
     sampleSize,
     buffer,
     ratio,
-    rotation,
-    randomRotation,
+    rotationOfGrid,
+    randomRotationOfGrid,
   });
   if (optionsError !== 0) {
     throw new RangeError(`samplePointsOnAreas error: ${optionsError}`);
@@ -143,7 +143,7 @@ export function samplePointsOnAreas(
         Geodesic.distance(center, bottomLeft),
         Geodesic.distance(center, topRight),
       );
-      const angle = randomRotation === true ? rand.float() * 360.0 : rotation;
+      const angle = randomRotationOfGrid === true ? rand.float() * 360.0 : rotationOfGrid;
       const dy = Math.sqrt(A / (sampleSize * ratio));
       const dx = ratio * dy;
       // generate random offset in x and y

--- a/packages/envisim-geosampling/src/sample-continuous/relascope-points.ts
+++ b/packages/envisim-geosampling/src/sample-continuous/relascope-points.ts
@@ -42,7 +42,7 @@ export function sampleRelascopePointsOptionsCheck(
     return 610;
   }
 
-  if (PropertyRecord.propertyIsNumerical(baseCollection.propertyRecord.getId(sizeProperty))) {
+  if (!PropertyRecord.propertyIsNumerical(baseCollection.propertyRecord.getId(sizeProperty))) {
     return 620;
   }
 

--- a/packages/envisim-geosampling/src/sample-stratified.ts
+++ b/packages/envisim-geosampling/src/sample-stratified.ts
@@ -20,9 +20,9 @@ import {SampleFiniteOptions} from './sample-finite/index.js';
 type SampleContinuousOptions =
   | SampleBaseOptions
   | SamplePointOptions
-  | SampleFeatureOptions<GJ.PointFeature>
-  | SampleFeatureOptions<GJ.LineFeature>
-  | SampleFeatureOptions<GJ.AreaFeature>
+  | SampleFeatureOptions<GJ.PointObject>
+  | SampleFeatureOptions<GJ.LineObject>
+  | SampleFeatureOptions<GJ.AreaObject>
   | SampleSystematicLineOnAreaOptions
   | SampleBeltOnAreaOptions;
 

--- a/packages/envisim-geosampling/tests/sample-continuous/features-on-areas.test.ts
+++ b/packages/envisim-geosampling/tests/sample-continuous/features-on-areas.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from 'vitest';
 
 import {Feature, FeatureCollection, Polygon} from '@envisim/geojson-utils';
 
-import {pointFeature, squareAreaFeature} from '../../src/model-feature.js';
+import {pointGeometry, squareAreaGeometry} from '../../src/model-geometry.js';
 import {sampleFeaturesOnAreas} from '../../src/sample-continuous/features-on-areas.js';
 
 const polygon = Polygon.create([
@@ -17,19 +17,19 @@ const polygon = Polygon.create([
 
 const frame = FeatureCollection.newArea([new Feature(polygon)]);
 
-const tract = squareAreaFeature(10);
+const tract = squareAreaGeometry(10);
 
 const sample = sampleFeaturesOnAreas(frame, {
   pointSelection: 'independent',
   sampleSize: 10,
-  modelFeature: tract,
+  modelGeometry: tract,
 });
 
-const tract2 = pointFeature();
+const tract2 = pointGeometry();
 const sample2 = sampleFeaturesOnAreas(frame, {
   pointSelection: 'independent',
   sampleSize: 10,
-  modelFeature: tract2,
+  modelGeometry: tract2,
 });
 
 test('sampleFeaturesOnAreas', () => {


### PR DESCRIPTION
Switched to using a model geometry and removed support for geometry collections in the model geometry (geosampling). Removed support for geometry collections also in cutLineGeometry and cutAreaGeometry (geojson-utils).