### PR TITLE
Bug fix in collect-properties

### DIFF
--- a/packages/envisim-geosampling/src/collect-properties.ts
+++ b/packages/envisim-geosampling/src/collect-properties.ts
@@ -134,7 +134,7 @@ export function collectProperties<PF extends string, PB extends string, GF exten
 
     // Add new properties to new collection and property record.
     // Initialize each with value 0
-    newCollection.forEach((f: Feature<PureObject, string>) => (f.properties[id] = 0.0));
+    newCollection.forEach((f: Feature<PureObject, string>) => (f.properties[property.id] = 0.0));
   }
 
   // Do the collect for the different cases.


### PR DESCRIPTION
* Fix error when collecting categorical properties. The parent id was added to features instead of the new id. The new id was then not initialized as 0, which caused error when aggregating values. Got null result instead of expected.