### PR TITLE
(geojson-utils) fix of bug in line-area intersect

### DIFF
--- a/packages/envisim-geojson-utils/tests/intersect/intersect-line-area.test.ts
+++ b/packages/envisim-geojson-utils/tests/intersect/intersect-line-area.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from 'vitest';
 
-import {FeatureCollection, LineString, MultiPolygon, Polygon} from '../../src/index.js';
+import {LineString, MultiPolygon, Polygon} from '../../src/index.js';
 import {intersectLineAreaGeometries} from '../../src/intersect/intersect-line-area.js';
 
 test('Simple polygon', () => {
@@ -111,4 +111,28 @@ test('line polygon bug report', () => {
       [20.31235315322874, 63.82127447446187],
     ].map((v) => [expect.closeTo(v[0], 9), expect.closeTo(v[1], 9)]),
   );
+});
+
+test('line polygon bug report 250317', () => {
+  const line = LineString.create([
+    [20.368015434414264, 63.81083569075],
+    [20.368713366796406, 63.81114416328356],
+  ]);
+
+  const area = Polygon.create([
+    [
+      [20.371132837866895, 63.81145573269143],
+      [20.368822702748304, 63.813133196968465],
+      [20.36503801329735, 63.81087004276483],
+      [20.36806904164547, 63.81080496535486],
+      [20.368150961330628, 63.81095681241095],
+      [20.36933060479572, 63.81095681241095],
+      [20.369232301173923, 63.81151357794957],
+      [20.371132837866895, 63.81145573269143],
+    ],
+  ]);
+
+  const int = intersectLineAreaGeometries(line, area);
+  expect(int.type).toBe('MultiLineString');
+  expect(int.coordinates.length).toBe(2);
 });


### PR DESCRIPTION
Fixes a bug that occurred when a line segment started and ended inside a polygon, but moved outside the polygon.