### PR TITLE
(geosampling) bugfix: delete properties on select intersect

### DIFF
--- a/packages/envisim-geosampling/src/select-intersects.ts
+++ b/packages/envisim-geosampling/src/select-intersects.ts
@@ -25,6 +25,8 @@ function createProperties<G1 extends PureObject, G2 extends PureObject, P extend
   parent: number,
 ): FeatureProperties<P> {
   const properties = {...baseFeature.properties};
+  delete properties['_measure'];
+  delete properties['_count'];
 
   // Transfer designWeight to newFeature from frameFeature
   if (frameFeature.properties?.['_designWeight'] !== undefined) {
@@ -42,6 +44,8 @@ function createPropertiesForLine<P extends string>(
   parent: number,
 ): FeatureProperties<P> {
   const properties = createProperties(frameFeature, baseFeature, parent);
+  delete properties['_measure'];
+  delete properties['_count'];
 
   if (properties['_designWeight'] === undefined) {
     return properties;


### PR DESCRIPTION
`_measure` needs to be deleted on `selectIntersect`.