### PR TITLE
(distributions) Remove duplicate class Intervals

### DIFF
--- a/.changeset/heavy-heads-clean.md
+++ b/.changeset/heavy-heads-clean.md
@@ -1,0 +1,5 @@
+---
+"@envisim/distributions": minor
+---
+
+Removed: export of class Interval

--- a/.changeset/shiny-grapes-trade.md
+++ b/.changeset/shiny-grapes-trade.md
@@ -1,0 +1,5 @@
+---
+"@envisim/utils": patch
+---
+
+Added: functions isLeftOfInterval, isRightOfInterval

--- a/packages/envisim-distributions/src/abstract-bounded.ts
+++ b/packages/envisim-distributions/src/abstract-bounded.ts
@@ -1,5 +1,5 @@
-import { ValidationError } from "@envisim/utils";
-import { Distribution, Interval } from "./abstract-distribution.js";
+import { ValidationError, type Interval } from "@envisim/utils";
+import { Distribution } from "./abstract-distribution.js";
 
 export class BoundedParams {
   static DEFAULTS = { a: 0.0, b: 1.0 } as const;
@@ -66,13 +66,14 @@ export class BoundedMidParams extends BoundedParams {
 }
 
 export abstract class Bounded extends Distribution {
+  declare support: Interval;
   /** @internal */
   #params!: BoundedParams;
 
-  constructor(a?: number, b?: number) {
-    super();
+  constructor(a?: number, b?: number, isContinuous: boolean = true) {
+    super(isContinuous);
     this.#params = new BoundedParams(a, b);
-    this.support = new Interval(this.#params.a, this.#params.b, false, false);
+    this.support = { interval: [this.#params.a, this.#params.b], ends: "closed" };
   }
 
   /** @internal */
@@ -85,10 +86,10 @@ export abstract class BoundedMid extends Distribution {
   /** @internal */
   #params!: BoundedMidParams;
 
-  constructor(a?: number, b?: number, mid?: number) {
-    super();
+  constructor(a?: number, b?: number, mid?: number, isContinuous: boolean = true) {
+    super(isContinuous);
     this.#params = new BoundedMidParams(a, b, mid);
-    this.support = new Interval(this.#params.a, this.#params.b, false, false);
+    this.support = { interval: [this.#params.a, this.#params.b], ends: "closed" };
   }
 
   /** @internal */

--- a/packages/envisim-distributions/src/abstract-location-scale.ts
+++ b/packages/envisim-distributions/src/abstract-location-scale.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from "@envisim/utils";
-import { Distribution, Interval } from "./abstract-distribution.js";
+import { Distribution } from "./abstract-distribution.js";
 
 export class LocationScaleParams {
   static DEFAULTS = { location: 0.0, scale: 1.0 } as const;
@@ -34,10 +34,9 @@ export abstract class LocationScale extends Distribution {
   /** @internal */
   #params!: LocationScaleParams;
 
-  constructor(location?: number, scale?: number) {
-    super();
+  constructor(location?: number, scale?: number, isContinuous: boolean = true) {
+    super(isContinuous);
     this.#params = new LocationScaleParams(location, scale);
-    this.support = new Interval(-Infinity, Infinity, true, true);
   }
 
   /** @internal */

--- a/packages/envisim-distributions/src/abstract-shape-scale.ts
+++ b/packages/envisim-distributions/src/abstract-shape-scale.ts
@@ -1,5 +1,5 @@
-import { ValidationError } from "@envisim/utils";
-import { Distribution, Interval } from "./abstract-distribution.js";
+import { type Interval, ValidationError } from "@envisim/utils";
+import { Distribution } from "./abstract-distribution.js";
 
 export class ShapeScaleParams {
   static DEFAULTS = { shape: 0.0, scale: 1.0 } as const;
@@ -30,13 +30,14 @@ export class ShapeScaleParams {
 }
 
 export abstract class ShapeScale extends Distribution {
+  declare support: Interval;
   /** @internal */
   #params!: ShapeScaleParams;
 
-  constructor(shape?: number, scale?: number) {
-    super();
+  constructor(shape?: number, scale?: number, isContinuous: boolean = true) {
+    super(isContinuous);
     this.#params = new ShapeScaleParams(shape, scale);
-    this.support = new Interval(0, Infinity, true, true);
+    this.support = { interval: [0.0, Infinity], ends: "open" };
   }
 
   /** @internal */

--- a/packages/envisim-distributions/src/continuous/arcsine.ts
+++ b/packages/envisim-distributions/src/continuous/arcsine.ts
@@ -15,27 +15,22 @@ export class Arcsine extends Bounded {
    */
   constructor(a?: number, b?: number) {
     super(a, b);
+    this.support.ends = "open";
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDF(x);
-    if (check !== null) return check;
-    if (x === this.params.a || x === this.params.b) return Infinity;
-
-    return 1.0 / (Math.PI * Math.sqrt((x - this.params.a) * (this.params.b - x)));
+  override pdf(x: number): number {
+    return super.pdf(x) ?? 1.0 / (Math.PI * Math.sqrt((x - this.params.a) * (this.params.b - x)));
   }
 
-  cdf(x: number): number {
+  override cdf(x: number): number {
     return (
-      this.support.checkCDF(x) ??
-      HALF_PI_INV * Math.asin(Math.sqrt((x - this.params.a) / this.params.width))
+      super.cdf(x) ?? HALF_PI_INV * Math.asin(Math.sqrt((x - this.params.a) / this.params.width))
     );
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     return (
-      this.support.checkQuantile(q) ??
-      Math.pow(Math.sin(q * HALF_PI), 2) * this.params.width + this.params.a
+      super.quantile(q) ?? Math.pow(Math.sin(q * HALF_PI), 2) * this.params.width + this.params.a
     );
   }
 

--- a/packages/envisim-distributions/src/continuous/benford-mantissa.ts
+++ b/packages/envisim-distributions/src/continuous/benford-mantissa.ts
@@ -1,6 +1,5 @@
 /** @group Parameter interfaces */
 import { Distribution } from "../abstract-distribution.js";
-import { Interval } from "../abstract-distribution.js";
 import { BenfordMantissaParams } from "../params.js";
 
 /**
@@ -23,7 +22,7 @@ export class BenfordMantissa extends Distribution {
   constructor(base?: number) {
     super();
     this.#params = new BenfordMantissaParams(base);
-    this.support = new Interval(1.0 / this.params.base, 1.0, false, true);
+    this.support = { interval: [1.0 / this.params.base, 1.0], ends: "right-open" };
   }
 
   /** @internal */
@@ -31,19 +30,19 @@ export class BenfordMantissa extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const { logBase } = this.params;
-    return this.support.checkPDF(x) ?? 1.0 / (x * logBase);
+    return super.pdf(x) ?? 1.0 / (x * logBase);
   }
 
-  cdf(x: number): number {
+  override cdf(x: number): number {
     const { logBase } = this.params;
-    return this.support.checkCDF(x) ?? 1 + Math.log(x) / logBase;
+    return super.cdf(x) ?? 1 + Math.log(x) / logBase;
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     const { base } = this.params;
-    return this.support.checkQuantile(q) ?? Math.pow(base, q - 1.0);
+    return super.quantile(q) ?? Math.pow(base, q - 1.0);
   }
 
   mean(): number {

--- a/packages/envisim-distributions/src/continuous/beta.ts
+++ b/packages/envisim-distributions/src/continuous/beta.ts
@@ -1,7 +1,6 @@
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
 } from "../abstract-distribution.js";
@@ -28,7 +27,7 @@ export class Beta extends Distribution {
   constructor(alpha?: number, beta?: number) {
     super();
     this.#params = new BetaParams(alpha, beta);
-    this.support = new Interval(0.0, 1.0, false, false);
+    this.support = { interval: [0.0, 1.0], ends: "closed" };
   }
 
   /** @internal */
@@ -36,22 +35,22 @@ export class Beta extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const alpha = this.params.alpha - 1.0;
     const beta = this.params.beta - 1.0;
 
     return (
-      this.support.checkPDF(x) ??
+      super.pdf(x) ??
       Math.exp(alpha * Math.log(x) + beta * Math.log(1.0 - x) - this.params.logBetaFunction())
     );
   }
 
-  cdf(x: number, eps: number = 1e-20): number {
-    return this.support.checkCDF(x) ?? this.params.regularizedBetaFunction(x, eps);
+  override cdf(x: number, eps: number = 1e-20): number {
+    return super.cdf(x) ?? this.params.regularizedBetaFunction(x, eps);
   }
 
-  quantile(q: number, eps: number = 1e-20): number {
-    return this.support.checkQuantile(q) ?? this.params.inverseRegularizedBetaFunction(q, eps);
+  override quantile(q: number, eps: number = 1e-20): number {
+    return super.quantile(q) ?? this.params.inverseRegularizedBetaFunction(q, eps);
   }
 
   override random(n: number = 1, options: RandomOptions = RANDOM_OPTIONS_DEFAULT): number[] {
@@ -105,7 +104,7 @@ export class BetaPrime extends Distribution {
   constructor(alpha?: number, beta?: number) {
     super();
     this.#params = new BetaParams(alpha, beta);
-    this.support = new Interval(0.0, Infinity, false, true);
+    this.support = { interval: [0.0, Infinity], ends: "right-open" };
   }
 
   /** @internal */
@@ -113,8 +112,8 @@ export class BetaPrime extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDF(x);
+  override pdf(x: number): number {
+    const check = super.pdf(x);
     if (check !== null) return check;
 
     const beta = this.params.alpha + this.params.beta;
@@ -126,12 +125,12 @@ export class BetaPrime extends Distribution {
     return Math.exp(alpha * Math.log(x) - beta * Math.log1p(x) - this.params.logBetaFunction());
   }
 
-  cdf(x: number, eps: number = 1e-20): number {
-    return this.support.checkCDF(x) ?? this.params.regularizedBetaFunction(x / (1 + x), eps);
+  override cdf(x: number, eps: number = 1e-20): number {
+    return super.cdf(x) ?? this.params.regularizedBetaFunction(x / (1 + x), eps);
   }
 
-  quantile(q: number, eps: number = 1e-20): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number, eps: number = 1e-20): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
     const inv = this.params.inverseRegularizedBetaFunction(q, eps);
     return inv / (1.0 - inv);

--- a/packages/envisim-distributions/src/continuous/cauchy.ts
+++ b/packages/envisim-distributions/src/continuous/cauchy.ts
@@ -18,20 +18,18 @@ export class Cauchy extends LocationScale {
     super(location, scale);
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const c = Math.PI * this.params.scale;
-
-    return this.support.checkPDF(x) ?? 1.0 / (c * (1.0 + Math.pow(this.params.normalize(x), 2)));
+    return 1.0 / (c * (1.0 + Math.pow(this.params.normalize(x), 2)));
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? 0.5 + Math.atan(this.params.normalize(x)) / Math.PI;
+  override cdf(x: number): number {
+    return 0.5 + Math.atan(this.params.normalize(x)) / Math.PI;
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     return (
-      this.support.checkQuantile(q) ??
-      this.params.location + this.params.scale * Math.tan(Math.PI * (q - 0.5))
+      super.quantile(q) ?? this.params.location + this.params.scale * Math.tan(Math.PI * (q - 0.5))
     );
   }
 

--- a/packages/envisim-distributions/src/continuous/exponential.ts
+++ b/packages/envisim-distributions/src/continuous/exponential.ts
@@ -1,7 +1,6 @@
 import { randomArray } from "@envisim/random";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
 } from "../abstract-distribution.js";
@@ -27,7 +26,7 @@ export class Exponential extends Distribution {
   constructor(rate?: number) {
     super();
     this.#params = new RateParams(rate);
-    this.support = new Interval(0, Infinity, false, true);
+    this.support = { interval: [0, Infinity], ends: "right-open" };
   }
 
   /** @internal */
@@ -35,16 +34,16 @@ export class Exponential extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
-    return this.support.checkPDF(x) ?? this.params.rate * Math.exp(-this.params.rate * x);
+  override pdf(x: number): number {
+    return super.pdf(x) ?? this.params.rate * Math.exp(-this.params.rate * x);
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? 1.0 - Math.exp(-this.params.rate * x);
+  override cdf(x: number): number {
+    return super.cdf(x) ?? 1.0 - Math.exp(-this.params.rate * x);
   }
 
-  quantile(q: number): number {
-    return this.support.checkQuantile(q) ?? -Math.log(1.0 - q) / this.params.rate;
+  override quantile(q: number): number {
+    return super.quantile(q) ?? -Math.log(1.0 - q) / this.params.rate;
   }
 
   override random(n: number = 1, options: RandomOptions = RANDOM_OPTIONS_DEFAULT): number[] {

--- a/packages/envisim-distributions/src/continuous/extreme-value.ts
+++ b/packages/envisim-distributions/src/continuous/extreme-value.ts
@@ -20,20 +20,17 @@ export class ExtremeValue extends LocationScale {
     super(location, scale);
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const exp = Math.exp(-this.params.normalize(x));
-    return this.support.checkPDF(x) ?? (exp * Math.exp(-exp)) / this.params.scale;
+    return (exp * Math.exp(-exp)) / this.params.scale;
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? Math.exp(-Math.exp(-this.params.normalize(x)));
+  override cdf(x: number): number {
+    return Math.exp(-Math.exp(-this.params.normalize(x)));
   }
 
-  quantile(q: number): number {
-    return (
-      this.support.checkQuantile(q) ??
-      this.params.location - Math.log(-Math.log(q)) * this.params.scale
-    );
+  override quantile(q: number): number {
+    return super.quantile(q) ?? this.params.location - Math.log(-Math.log(q)) * this.params.scale;
   }
 
   mean(): number {

--- a/packages/envisim-distributions/src/continuous/f-ratio.ts
+++ b/packages/envisim-distributions/src/continuous/f-ratio.ts
@@ -1,7 +1,6 @@
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
 } from "../abstract-distribution.js";
@@ -32,7 +31,10 @@ export class FRatio extends Distribution {
     super();
     this.#params = [new DegreesOfFreedomParams(df1), new DegreesOfFreedomParams(df2)];
     this.#beta = new BetaParams(this.#params[0].df * 0.5, this.#params[1].df * 0.5);
-    this.support = new Interval(0, Infinity, this.#params[0].df === 1, true);
+    this.support = {
+      interval: [0, Infinity],
+      ends: this.#params[0].df === 1 ? "open" : "right-open",
+    };
   }
 
   /** @internal */
@@ -40,32 +42,29 @@ export class FRatio extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const dfFrac = this.params[0].df / this.params[1].df;
     const c = this.#beta.alpha * Math.log(dfFrac) - this.#beta.logBetaFunction();
     const dfHalfSum = this.#beta.alpha + this.#beta.beta;
 
     return (
-      this.support.checkPDF(x) ??
+      super.pdf(x) ??
       Math.exp(c + (this.#beta.alpha - 1.0) * Math.log(x) - dfHalfSum * Math.log1p(dfFrac * x))
     );
   }
 
-  cdf(x: number, eps: number = 1e-20): number {
+  override cdf(x: number, eps: number = 1e-20): number {
     const dfx = this.params[0].df * x;
 
-    return (
-      this.support.checkCDF(x) ??
-      this.#beta.regularizedBetaFunction(dfx / (dfx + this.params[1].df), eps)
-    );
+    return super.cdf(x) ?? this.#beta.regularizedBetaFunction(dfx / (dfx + this.params[1].df), eps);
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     const dfFrac = this.params[1].df / this.params[0].df;
     const beta = new BetaParams(this.#params[1].df * 0.5, this.#params[0].df * 0.5);
 
     return (
-      this.support.checkQuantile(q) ??
+      super.quantile(q) ??
       (1.0 / beta.inverseRegularizedBetaFunction(1.0 - q, this.#beta.logBetaFunction()) - 1.0) *
         dfFrac
     );

--- a/packages/envisim-distributions/src/continuous/gamma.ts
+++ b/packages/envisim-distributions/src/continuous/gamma.ts
@@ -27,23 +27,20 @@ export class Gamma extends ShapeScale {
     this.#lgf = logGammaFunction(this.params.shape);
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const scale = this.params.scale;
     const c = this.#lgf + this.params.shape * Math.log(scale);
     const shape = this.params.shape - 1.0;
 
-    return this.support.checkPDF(x) ?? Math.exp(shape * Math.log(x) - x / scale - c);
+    return Math.exp(shape * Math.log(x) - x / scale - c);
   }
 
-  cdf(x: number, eps: number = 1e-12): number {
-    return (
-      this.support.checkCDF(x) ??
-      regularizedLowerGammaFunction(this.params.shape, x / this.params.scale, eps, this.#lgf)
-    );
+  override cdf(x: number, eps: number = 1e-12): number {
+    return regularizedLowerGammaFunction(this.params.shape, x / this.params.scale, eps, this.#lgf);
   }
 
-  quantile(q: number, eps: number = 1e-12): number {
-    return this.support.checkQuantile(q) ?? gammaQuantile.call(this.params, q, eps, this.#lgf);
+  override quantile(q: number, eps: number = 1e-12): number {
+    return super.quantile(q) ?? gammaQuantile.call(this.params, q, eps, this.#lgf);
   }
 
   override random(n: number = 1, options: RandomOptions = RANDOM_OPTIONS_DEFAULT): number[] {

--- a/packages/envisim-distributions/src/continuous/hyperbolic-secant.ts
+++ b/packages/envisim-distributions/src/continuous/hyperbolic-secant.ts
@@ -1,4 +1,4 @@
-import { Distribution, Interval } from "../abstract-distribution.js";
+import { Distribution } from "../abstract-distribution.js";
 import { HALF_PI } from "../math-constants.js";
 import { sech } from "../utils.js";
 
@@ -18,19 +18,18 @@ export class HyperbolicSecant extends Distribution {
    */
   constructor() {
     super();
-    this.support = new Interval(-Infinity, Infinity, true, true);
   }
 
-  pdf(x: number): number {
-    return this.support.checkPDF(x) ?? sech(HALF_PI * x) * 0.5;
+  override pdf(x: number): number {
+    return sech(HALF_PI * x) * 0.5;
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? Math.atan(Math.exp(HALF_PI * x)) / HALF_PI;
+  override cdf(x: number): number {
+    return Math.atan(Math.exp(HALF_PI * x)) / HALF_PI;
   }
 
-  quantile(q: number): number {
-    return this.support.checkQuantile(q) ?? Math.log(Math.tan(q * HALF_PI)) / HALF_PI;
+  override quantile(q: number): number {
+    return super.quantile(q) ?? Math.log(Math.tan(q * HALF_PI)) / HALF_PI;
   }
 
   mean(): number {

--- a/packages/envisim-distributions/src/continuous/laplace.ts
+++ b/packages/envisim-distributions/src/continuous/laplace.ts
@@ -18,23 +18,18 @@ export class Laplace extends LocationScale {
     super(location, scale);
   }
 
-  pdf(x: number): number {
-    return (
-      this.support.checkPDF(x) ??
-      (Math.exp(-Math.abs(this.params.normalize(x))) * 0.5) / this.params.scale
-    );
+  override pdf(x: number): number {
+    return (Math.exp(-Math.abs(this.params.normalize(x))) * 0.5) / this.params.scale;
   }
 
-  cdf(x: number): number {
-    const check = this.support.checkCDF(x);
-    if (check !== null) return check;
+  override cdf(x: number): number {
     const z = this.params.normalize(x);
     if (x <= this.params.location) return Math.exp(z) * 0.5;
     return 1 - Math.exp(-z) * 0.5;
   }
 
-  quantile(q: number): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
     if (q <= 0.5) return this.params.location + this.params.scale * Math.log(2.0 * q);
     return this.params.location - this.params.scale * Math.log(2.0 * (1.0 - q));

--- a/packages/envisim-distributions/src/continuous/logistic.ts
+++ b/packages/envisim-distributions/src/continuous/logistic.ts
@@ -1,4 +1,3 @@
-import { Interval } from "../abstract-distribution.js";
 import { LocationScale } from "../abstract-location-scale.js";
 import { ShapeScale } from "../abstract-shape-scale.js";
 
@@ -20,22 +19,17 @@ export class Logistic extends LocationScale {
     super(location, scale);
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDF(x);
-    if (check !== null) return check;
+  override pdf(x: number): number {
     const exp = Math.exp(-this.params.normalize(x));
     return exp / (this.params.scale * Math.pow(exp + 1.0, 2));
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? 1.0 / (1.0 + Math.exp(-this.params.normalize(x)));
+  override cdf(x: number): number {
+    return 1.0 / (1.0 + Math.exp(-this.params.normalize(x)));
   }
 
-  quantile(q: number): number {
-    return (
-      this.support.checkQuantile(q) ??
-      this.params.location - this.params.scale * Math.log(1.0 / q - 1.0)
-    );
+  override quantile(q: number): number {
+    return super.quantile(q) ?? this.params.location - this.params.scale * Math.log(1.0 / q - 1.0);
   }
 
   mean(): number {
@@ -72,28 +66,25 @@ export class LogLogistic extends ShapeScale {
    */
   constructor(shape?: number, scale?: number) {
     super(shape, scale);
-    this.support = new Interval(0.0, Infinity, false, true);
+    this.support = { interval: [0.0, Infinity], ends: "right-open" };
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const c = this.params.shape / this.params.scale;
     const shapem1 = this.params.shape - 1.0;
     const frac = x / this.params.scale;
     const pow = Math.pow(frac, shapem1);
 
-    return this.support.checkPDF(x) ?? (c * pow) / Math.pow(1.0 + pow * frac, 2);
+    return super.pdf(x) ?? (c * pow) / Math.pow(1.0 + pow * frac, 2);
   }
 
-  cdf(x: number): number {
-    return (
-      this.support.checkCDF(x) ?? 1.0 / (1.0 + Math.pow(x / this.params.scale, -this.params.shape))
-    );
+  override cdf(x: number): number {
+    return super.cdf(x) ?? 1.0 / (1.0 + Math.pow(x / this.params.scale, -this.params.shape));
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     const c = 1.0 / this.params.shape;
-
-    return this.support.checkQuantile(q) ?? this.params.scale * Math.pow(q / (1.0 - q), c);
+    return super.quantile(q) ?? this.params.scale * Math.pow(q / (1.0 - q), c);
   }
 
   mean(): number {

--- a/packages/envisim-distributions/src/continuous/pareto.ts
+++ b/packages/envisim-distributions/src/continuous/pareto.ts
@@ -1,4 +1,3 @@
-import { Interval } from "../abstract-distribution.js";
 import { ShapeScale } from "../abstract-shape-scale.js";
 
 /**
@@ -17,22 +16,22 @@ export class Pareto extends ShapeScale {
    */
   constructor(shape?: number, scale?: number) {
     super(shape, scale);
-    this.support = new Interval(this.params.scale, Infinity, false, true);
+    this.support = { interval: [this.params.scale, Infinity], ends: "right-open" };
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const c = Math.log(this.params.shape) + this.params.shape * Math.log(this.params.scale);
     const shape = this.params.shape + 1.0;
-    return this.support.checkPDF(x) ?? Math.exp(c - shape * Math.log(x));
+    return super.pdf(x) ?? Math.exp(c - shape * Math.log(x));
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? 1.0 - Math.pow(this.params.scale / x, this.params.shape);
+  override cdf(x: number): number {
+    return super.cdf(x) ?? 1.0 - Math.pow(this.params.scale / x, this.params.shape);
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     const c = 1.0 / this.params.shape;
-    return this.support.checkQuantile(q) ?? this.params.scale / Math.pow(1.0 - q, c);
+    return super.quantile(q) ?? this.params.scale / Math.pow(1.0 - q, c);
   }
 
   mean(): number {

--- a/packages/envisim-distributions/src/continuous/semicircle.ts
+++ b/packages/envisim-distributions/src/continuous/semicircle.ts
@@ -1,7 +1,6 @@
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
 } from "../abstract-distribution.js";
@@ -31,7 +30,7 @@ export class Semicircle extends Distribution {
   constructor(radius?: number) {
     super();
     this.#params = new RadiusParams(radius);
-    this.support = new Interval(-this.#params.radius, this.#params.radius, false, false);
+    this.support = { interval: [-this.#params.radius, this.#params.radius], ends: "closed" };
   }
 
   /** @internal */
@@ -39,24 +38,23 @@ export class Semicircle extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const { radiusSquared, denom } = this.params;
-    return this.support.checkPDF(x) ?? Math.sqrt(radiusSquared - Math.pow(x, 2)) * denom * 2.0;
+    return super.pdf(x) ?? Math.sqrt(radiusSquared - Math.pow(x, 2)) * denom * 2.0;
   }
 
-  cdf(x: number): number {
+  override cdf(x: number): number {
     const { radius, radiusSquared, denom } = this.params;
     return (
-      this.support.checkCDF(x) ??
+      super.cdf(x) ??
       0.5 + x * Math.sqrt(radiusSquared - Math.pow(x, 2)) * denom + Math.asin(x / radius) / Math.PI
     );
   }
 
-  quantile(q: number, eps: number = 1e-20): number {
+  override quantile(q: number, eps: number = 1e-20): number {
     const { radius } = this.params;
     return (
-      this.support.checkQuantile(q) ??
-      (this.#beta.inverseRegularizedBetaFunction(q, eps) - 0.5) * 2.0 * radius
+      super.quantile(q) ?? (this.#beta.inverseRegularizedBetaFunction(q, eps) - 0.5) * 2.0 * radius
     );
   }
 

--- a/packages/envisim-distributions/src/continuous/u-quadratic.ts
+++ b/packages/envisim-distributions/src/continuous/u-quadratic.ts
@@ -27,19 +27,19 @@ export class UQuadratic extends Bounded {
     return super.params;
   }
 
-  pdf(x: number): number {
-    return this.support.checkPDF(x) ?? this.#alpha * Math.pow(x - this.#beta, 2);
+  override pdf(x: number): number {
+    return super.pdf(x) ?? this.#alpha * Math.pow(x - this.#beta, 2);
   }
 
-  cdf(x: number): number {
+  override cdf(x: number): number {
     const c1 = this.#alpha / 3.0;
     const c2 = Math.pow(this.#beta - this.params.a, 3);
 
-    return this.support.checkCDF(x) ?? c1 * (c2 + Math.pow(x - this.#beta, 3));
+    return super.cdf(x) ?? c1 * (c2 + Math.pow(x - this.#beta, 3));
   }
 
-  quantile(q: number): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const c1 = Math.pow(this.params.b - this.params.a, 3) * 0.25;

--- a/packages/envisim-distributions/src/continuous/uniform.ts
+++ b/packages/envisim-distributions/src/continuous/uniform.ts
@@ -22,16 +22,16 @@ export class Uniform extends Bounded {
     super(a, b);
   }
 
-  pdf(x: number): number {
-    return this.support.checkPDF(x) ?? 1.0 / this.params.width;
+  override pdf(x: number): number {
+    return super.pdf(x) ?? 1.0 / this.params.width;
   }
 
-  cdf(x: number): number {
-    return this.support.checkCDF(x) ?? (x - this.params.a) / this.params.width;
+  override cdf(x: number): number {
+    return super.cdf(x) ?? (x - this.params.a) / this.params.width;
   }
 
-  quantile(q: number): number {
-    return this.support.checkQuantile(q) ?? this.params.a + q * this.params.width;
+  override quantile(q: number): number {
+    return super.quantile(q) ?? this.params.a + q * this.params.width;
   }
 
   override random(n: number = 1, options: RandomOptions = RANDOM_OPTIONS_DEFAULT): number[] {
@@ -78,8 +78,8 @@ export class Triangular extends BoundedMid {
     super(a, b, mid);
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDF(x);
+  override pdf(x: number): number {
+    const check = super.pdf(x);
     if (check !== null) return check;
 
     const c1 = 2.0 / this.params.width;
@@ -91,8 +91,8 @@ export class Triangular extends BoundedMid {
     return c3 * (this.params.b - x);
   }
 
-  cdf(x: number): number {
-    const check = this.support.checkCDF(x);
+  override cdf(x: number): number {
+    const check = super.cdf(x);
     if (check !== null) return check;
 
     const c1 = 1.0 / (this.params.awidth * this.params.width);
@@ -102,8 +102,8 @@ export class Triangular extends BoundedMid {
     return 1.0 - Math.pow(this.params.b - x, 2) * c2;
   }
 
-  quantile(q: number): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const c1 = this.params.width;

--- a/packages/envisim-distributions/src/continuous/weibull.ts
+++ b/packages/envisim-distributions/src/continuous/weibull.ts
@@ -1,4 +1,3 @@
-import { Interval } from "../abstract-distribution.js";
 import { ShapeScale } from "../abstract-shape-scale.js";
 import { gammaFunction } from "../gamma-utils.js";
 
@@ -18,11 +17,11 @@ export class Weibull extends ShapeScale {
    */
   constructor(shape?: number, scale?: number) {
     super(shape, scale);
-    this.support = new Interval(0, Infinity, false, true);
+    this.support = { interval: [0, Infinity], ends: "right-open" };
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDF(x);
+  override pdf(x: number): number {
+    const check = super.pdf(x);
     if (check !== null) return check;
 
     const c1 = Math.log(this.params.shape);
@@ -35,15 +34,12 @@ export class Weibull extends ShapeScale {
     return Math.exp(c1 - c2 + ly * shapem1 - Math.exp(this.params.shape * ly - c2));
   }
 
-  cdf(x: number): number {
-    return (
-      this.support.checkCDF(x) ??
-      1.0 - Math.exp(-Math.pow(x / this.params.scale, this.params.shape))
-    );
+  override cdf(x: number): number {
+    return super.cdf(x) ?? 1.0 - Math.exp(-Math.pow(x / this.params.scale, this.params.shape));
   }
 
-  quantile(q: number): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const c1 = 1.0 / this.params.shape;

--- a/packages/envisim-distributions/src/discrete/bernoulli.ts
+++ b/packages/envisim-distributions/src/discrete/bernoulli.ts
@@ -1,4 +1,4 @@
-import { Distribution, Interval } from "../abstract-distribution.js";
+import { Distribution } from "../abstract-distribution.js";
 import { BernoulliParams } from "../params.js";
 
 /**
@@ -17,9 +17,9 @@ export class Bernoulli extends Distribution {
    * x.quantile(0.5)
    */
   constructor(p?: number) {
-    super();
+    super(false);
     this.#params = new BernoulliParams(p);
-    this.support = new Interval(0, Infinity, false, true);
+    this.support = { interval: [0, 1], ends: "closed" };
   }
 
   /** @internal */
@@ -27,7 +27,7 @@ export class Bernoulli extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     if (x === 0) {
       return this.params.q;
     } else if (x === 1) {
@@ -37,7 +37,7 @@ export class Bernoulli extends Distribution {
     }
   }
 
-  cdf(x: number): number {
+  override cdf(x: number): number {
     if (x < 0) {
       return 0.0;
     } else if (x < 1) {
@@ -47,7 +47,7 @@ export class Bernoulli extends Distribution {
     }
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     if (q < 0.0 || q > 1.0) {
       return NaN;
     } else if (q <= this.params.q) {

--- a/packages/envisim-distributions/src/discrete/binomial.ts
+++ b/packages/envisim-distributions/src/discrete/binomial.ts
@@ -1,7 +1,6 @@
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
   cornishFisherExpansion,
@@ -33,9 +32,9 @@ export class Binomial extends Distribution {
    * x.random(10);
    */
   constructor(n?: number, p?: number) {
-    super();
+    super(false);
     this.#params = new BinomialParams(n, p);
-    this.support = new Interval(0, this.params.n, false, false);
+    this.support = { interval: [0, this.params.n], ends: "closed" };
   }
 
   /** @internal */
@@ -43,26 +42,26 @@ export class Binomial extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const p = Math.log(this.params.p);
     const q = this.params.logq;
 
     return (
-      this.support.checkPDFInt(x) ??
+      super.pdf(x) ??
       Math.exp(logBinomialCoefficient(this.params.n, x) + x * p + (this.params.n - x) * q)
     );
   }
 
-  cdf(x: number, eps: number = 1e-20): number {
+  override cdf(x: number, eps: number = 1e-20): number {
     const xl = x | 0;
     return (
-      this.support.checkCDFInt(x) ??
+      super.cdf(x) ??
       new BetaParams(this.params.n - xl, xl + 1).regularizedBetaFunction(this.params.q, eps)
     );
   }
 
-  quantile(q: number, eps: number = 1e-20): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number, eps: number = 1e-20): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const z = stdNormalQuantile(q);
@@ -118,9 +117,9 @@ export class NegativeBinomial extends Distribution {
    * x.random(10);
    */
   constructor(n?: number, p?: number) {
-    super();
+    super(false);
     this.#params = new BinomialParams(n, p);
-    this.support = new Interval(0, Infinity, false, true);
+    this.support = { interval: [0, Infinity], ends: "right-open" };
   }
 
   /** @internal */
@@ -128,25 +127,25 @@ export class NegativeBinomial extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const p = Math.log(this.params.p);
     const q = this.params.logq;
 
     return (
-      this.support.checkPDFInt(x) ??
+      super.pdf(x) ??
       Math.exp(logBinomialCoefficient(x + this.params.n - 1, x) + x * p + this.params.n * q)
     );
   }
 
-  cdf(x: number, eps: number = 1e-20): number {
+  override cdf(x: number, eps: number = 1e-20): number {
     return (
-      this.support.checkCDFInt(x) ??
+      super.cdf(x) ??
       1.0 - new BetaParams((x | 0) + 1, this.params.n).regularizedBetaFunction(this.params.p, eps)
     );
   }
 
-  quantile(q: number, eps: number = 1e-20): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number, eps: number = 1e-20): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const z = stdNormalQuantile(q);

--- a/packages/envisim-distributions/src/discrete/geometric.ts
+++ b/packages/envisim-distributions/src/discrete/geometric.ts
@@ -1,10 +1,13 @@
-import { Interval } from "../abstract-distribution.js";
-import { Bernoulli } from "./bernoulli.js";
+import { Distribution } from "../abstract-distribution.js";
+import { BernoulliParams } from "../params.js";
 
 /**
  * @category Discrete distributions
  */
-export class Geometric extends Bernoulli {
+export class Geometric extends Distribution {
+  /** @internal */
+  #params!: BernoulliParams;
+
   /**
    * The Geometric distribution
    *
@@ -16,35 +19,41 @@ export class Geometric extends Bernoulli {
    * x.random(10);
    */
   constructor(p?: number) {
-    super(p);
-    this.support = new Interval(1, Infinity, false, true);
+    super(false);
+    this.#params = new BernoulliParams(p);
+    this.support = { interval: [1, Infinity], ends: "right-open" };
+  }
+
+  /** @internal */
+  get params() {
+    return this.#params;
   }
 
   override pdf(x: number): number {
-    return this.support.checkPDFInt(x) ?? Math.exp((x - 1) * this.params.logq) * this.params.p;
+    return super.pdf(x) ?? Math.exp((x - 1) * this.params.logq) * this.params.p;
   }
 
   override cdf(x: number): number {
-    return this.support.checkCDFInt(x) ?? 1.0 - Math.exp((x | 0) * this.params.logq);
+    return super.cdf(x) ?? 1.0 - Math.exp((x | 0) * this.params.logq);
   }
 
   override quantile(q: number): number {
-    return this.support.checkQuantile(q) ?? Math.ceil(Math.log(1.0 - q) / this.params.logq);
+    return super.quantile(q) ?? Math.ceil(Math.log(1.0 - q) / this.params.logq);
   }
 
-  override mean(): number {
+  mean(): number {
     return 1.0 / this.params.p;
   }
 
-  override variance(): number {
+  variance(): number {
     return this.params.q / Math.pow(this.params.p, 2);
   }
 
-  override mode(): number {
+  mode(): number {
     return 1.0;
   }
 
-  override skewness(): number {
+  skewness(): number {
     return (1.0 + this.params.q) / Math.sqrt(this.params.q);
   }
 }

--- a/packages/envisim-distributions/src/discrete/hypergeometric.ts
+++ b/packages/envisim-distributions/src/discrete/hypergeometric.ts
@@ -2,7 +2,6 @@ import { type RandomGenerator } from "@envisim/random";
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
 } from "../abstract-distribution.js";
@@ -28,14 +27,15 @@ export class Hypergeometric extends Distribution {
    * x.random(10);
    */
   constructor(N?: number, K?: number, n?: number) {
-    super();
+    super(false);
     this.#params = new HypergeometricParams(N, K, n);
-    this.support = new Interval(
-      Math.max(0, this.#params.n + this.#params.K - this.#params.N),
-      Math.min(this.#params.n, this.#params.K),
-      false,
-      true,
-    );
+    this.support = {
+      interval: [
+        Math.max(0, this.#params.n + this.#params.K - this.#params.N),
+        Math.min(this.#params.n, this.#params.K),
+      ],
+      ends: "right-open",
+    };
   }
 
   /** @internal */
@@ -43,8 +43,8 @@ export class Hypergeometric extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
-    const check = this.support.checkPDFInt(x);
+  override pdf(x: number): number {
+    const check = super.pdf(x);
     if (check !== null) {
       return check;
     } else if (this.params.n === 0 || this.params.K === 0) {
@@ -79,7 +79,7 @@ export class Hypergeometric extends Distribution {
    * R-project.
    * https://bugs.r-project.org/show_bug.cgi?id=6772
    */
-  cdf(x: number, eps: number = 1e-12): number {
+  override cdf(x: number, eps: number = 1e-12): number {
     let NK = this.params.K;
     let KN = this.params.N - this.params.K;
 
@@ -117,7 +117,7 @@ export class Hypergeometric extends Distribution {
     return flip ? 1.0 - s * pdf : s * pdf;
   }
 
-  quantile(q: number): number {
+  override quantile(q: number): number {
     if (q < 0.0 || q > 1.0) return NaN;
     let NK = this.params.K;
     let KN = this.params.N - this.params.K;

--- a/packages/envisim-distributions/src/discrete/poisson.ts
+++ b/packages/envisim-distributions/src/discrete/poisson.ts
@@ -1,7 +1,6 @@
 import { ValidationError } from "@envisim/utils";
 import {
   Distribution,
-  Interval,
   type RandomOptions,
   RANDOM_OPTIONS_DEFAULT,
   quantileCF,
@@ -31,9 +30,9 @@ export class Poisson extends Distribution {
    * x.random(10);
    */
   constructor(rate?: number) {
-    super();
+    super(false);
     this.#params = new RateParams(rate);
-    this.support = new Interval(0, Infinity, false, true);
+    this.support = { interval: [0, Infinity], ends: "right-open" };
   }
 
   /** @internal */
@@ -41,18 +40,18 @@ export class Poisson extends Distribution {
     return this.#params;
   }
 
-  pdf(x: number): number {
+  override pdf(x: number): number {
     const lrate = Math.log(this.params.rate);
-    return this.support.checkPDFInt(x) ?? Math.exp(x * lrate - this.params.rate - logFactorial(x));
+    return super.pdf(x) ?? Math.exp(x * lrate - this.params.rate - logFactorial(x));
   }
 
-  cdf(x: number, eps: number = 1e-12): number {
-    const xl = (x | 0) + 1;
-    return this.support.checkCDFInt(x) ?? regularizedUpperGammaFunction(xl, this.params.rate, eps);
+  override cdf(x: number, eps: number = 1e-12): number {
+    const xl = Math.trunc(x) + 1;
+    return super.cdf(x) ?? regularizedUpperGammaFunction(xl, this.params.rate, eps);
   }
 
-  quantile(q: number, eps: number = 1e-12): number {
-    const check = this.support.checkQuantile(q);
+  override quantile(q: number, eps: number = 1e-12): number {
+    const check = super.quantile(q);
     if (check !== null) return check;
 
     const z = stdNormalQuantile(q);

--- a/packages/envisim-distributions/src/discrete/uniform.ts
+++ b/packages/envisim-distributions/src/discrete/uniform.ts
@@ -1,12 +1,12 @@
 import { randomArray } from "@envisim/random";
 import { ValidationError } from "@envisim/utils";
+import { Bounded } from "../abstract-bounded.js";
 import { type RandomOptions, RANDOM_OPTIONS_DEFAULT } from "../abstract-distribution.js";
-import { Uniform } from "../continuous/uniform.js";
 
 /**
  * @category Discrete distributions
  */
-export class UniformDiscrete extends Uniform {
+export class UniformDiscrete extends Bounded {
   /**
    * The Uniform (discrete) distribution
    *
@@ -18,26 +18,25 @@ export class UniformDiscrete extends Uniform {
    * x.random(10);
    */
   constructor(a: number, b: number) {
-    super(Math.trunc(a), Math.trunc(b));
+    super(Math.trunc(a), Math.trunc(b), false);
   }
 
   override pdf(x: number): number {
-    const c = 1.0 / (this.params.width + 1);
-    return this.support.checkPDFInt(x) ?? c;
+    return super.pdf(x) ?? 1.0 / (this.params.width + 1);
   }
 
   override cdf(x: number): number {
     const c1 = 1 - this.params.a;
     const c2 = 1.0 / (this.params.b + c1);
 
-    return this.support.checkCDFInt(x) ?? (Math.floor(x) + c1) * c2;
+    return super.cdf(x) ?? (Math.floor(x) + c1) * c2;
   }
 
   override quantile(q: number): number {
     const c1 = 1 - this.params.a;
     const c2 = this.params.b + c1;
 
-    return this.support.checkQuantile(q) ?? Math.ceil(q * c2) - c1;
+    return super.quantile(q) ?? Math.ceil(q * c2) - c1;
   }
 
   override random(n: number = 1, options: RandomOptions = RANDOM_OPTIONS_DEFAULT): number[] {
@@ -47,8 +46,18 @@ export class UniformDiscrete extends Uniform {
     return randomArray(n, options.rand).map((e) => this.params.a + Math.floor(c * e));
   }
 
-  override variance(): number {
+  mean(): number {
+    const { a, b } = this.params;
+    return (a + b) / 2.0;
+  }
+  variance(): number {
     const { a, b } = this.params;
     return (Math.pow(b - a + 1, 2) - 1) / 12;
+  }
+  mode(): number {
+    return this.params.a;
+  }
+  skewness(): number {
+    return 0.0;
   }
 }

--- a/packages/envisim-distributions/src/index.ts
+++ b/packages/envisim-distributions/src/index.ts
@@ -6,3 +6,4 @@ export * from "./continuous/index.js";
 export * from "./discrete/index.js";
 
 export type { RandomOptions } from "./abstract-distribution.js";
+export type { ContinuousDistribution, DiscreteDistribution } from "./types.js";

--- a/packages/envisim-distributions/src/index.ts
+++ b/packages/envisim-distributions/src/index.ts
@@ -5,4 +5,4 @@
 export * from "./continuous/index.js";
 export * from "./discrete/index.js";
 
-export type { RandomOptions, Interval } from "./abstract-distribution.js";
+export type { RandomOptions } from "./abstract-distribution.js";

--- a/packages/envisim-distributions/src/types.ts
+++ b/packages/envisim-distributions/src/types.ts
@@ -1,0 +1,5 @@
+import type * as Continuous from "./continuous/index.js";
+import type * as Discrete from "./discrete/index.js";
+
+export type ContinuousDistribution = InstanceType<(typeof Continuous)[keyof typeof Continuous]>;
+export type DiscreteDistribution = InstanceType<(typeof Discrete)[keyof typeof Discrete]>;

--- a/packages/envisim-distributions/tests/continuous/arcsine.test.ts
+++ b/packages/envisim-distributions/tests/continuous/arcsine.test.ts
@@ -1,21 +1,12 @@
-import {describe} from 'vitest';
+import { describe } from "vitest";
+import { Arcsine } from "../../src/index.js";
+import { distributionTests, fromTo } from "../_distributions.testf.js";
 
-import {Arcsine} from '../../src/index.js';
-import {distributionTests, fromTo} from '../_distributions.testf.js';
-
-describe('Arcsine(-1, 1)', () => {
+describe("Arcsine(-1, 1)", () => {
   const pdf = [
-    Infinity,
-    0.53051647697298442985,
-    0.3978873577297383779,
-    0.34730455902142837177,
-    0.3248736671806984333,
-    0.31830988618379069122,
-    0.3248736671806984333,
-    0.34730455902142837177,
-    0.3978873577297383779,
-    0.53051647697298442985,
-    Infinity,
+    0.0, 0.53051647697298442985, 0.3978873577297383779, 0.34730455902142837177,
+    0.3248736671806984333, 0.31830988618379069122, 0.3248736671806984333, 0.34730455902142837177,
+    0.3978873577297383779, 0.53051647697298442985, 0.0,
   ];
   const cdf = [
     0.0, 0.20483276469913341833, 0.29516723530086652616, 0.36901011956554535809,
@@ -29,5 +20,5 @@ describe('Arcsine(-1, 1)', () => {
   ];
   const x = fromTo(-1, 1.01, 0.2);
 
-  distributionTests(new Arcsine(-1.0, 1.0), {x, pdf, cdf, quantile});
+  distributionTests(new Arcsine(-1.0, 1.0), { x, pdf, cdf, quantile });
 });

--- a/packages/envisim-utils/src/index.ts
+++ b/packages/envisim-utils/src/index.ts
@@ -11,7 +11,13 @@ export {
   type ValidationErrorCreator,
   type ValidationErrorChecker,
 } from "./errors.js";
-export { inInterval, inUnitInterval, type Interval } from "./interval.js";
+export {
+  inInterval,
+  isLeftOfInterval,
+  isRightOfInterval,
+  inUnitInterval,
+  type Interval,
+} from "./interval.js";
 export { reducedRowEchelonForm } from "./reducedRowEchelonForm.js";
 export { swap } from "./swap.js";
 

--- a/packages/envisim-utils/src/interval.ts
+++ b/packages/envisim-utils/src/interval.ts
@@ -1,23 +1,69 @@
 export interface Interval {
+  /** The [left, right] bounds of the interval */
   interval: [number] | [number, number];
+  /** The openness of the interval */
   ends?: "closed" | "open" | "left-open" | "right-open";
 }
 
-export function inInterval(x: number, { interval, ends = "closed" }: Interval): boolean {
+/**
+ * @param x -
+ * @returns `true` if `x` is within the interval
+ */
+export function inInterval(
+  x: number,
+  { interval: [a, b = Infinity], ends = "closed" }: Interval,
+): boolean {
   if (!Number.isFinite(x)) return false;
 
   switch (ends) {
     case "closed":
-      return interval[0] <= x && (interval[1] === undefined || x <= interval[1]);
+      return a <= x && x <= b;
     case "open":
-      return interval[0] < x && (interval[1] === undefined || x < interval[1]);
+      return a < x && x < b;
     case "left-open":
-      return interval[0] < x && (interval[1] === undefined || x <= interval[1]);
+      return a < x && x <= b;
     case "right-open":
-      return interval[0] <= x && (interval[1] === undefined || x < interval[1]);
+      return a <= x && x < b;
   }
 }
 
+/**
+ * @param x -
+ * @returns `true` if `x` is to the left of the interval
+ */
+export function isLeftOfInterval(x: number, { interval: [a], ends = "closed" }: Interval): boolean {
+  switch (ends) {
+    case "open":
+    case "left-open":
+      return x <= a;
+    case "closed":
+    case "right-open":
+      return x < a;
+  }
+}
+
+/**
+ * @param x -
+ * @returns `true` if `x` is to the right of the interval
+ */
+export function isRightOfInterval(
+  x: number,
+  { interval: [_, b = Infinity], ends = "closed" }: Interval,
+): boolean {
+  switch (ends) {
+    case "open":
+    case "right-open":
+      return b <= x;
+    case "closed":
+    case "left-open":
+      return b < x;
+  }
+}
+
+/**
+ * @param x -
+ * @returns `true` if `x` is within the unit interval
+ */
 export function inUnitInterval(
   x: number,
   { ends = "closed" }: Omit<Interval, "interval"> = {},
@@ -34,6 +80,9 @@ export function inUnitInterval(
   }
 }
 
+/**
+ * @returns a string representation of the interval
+ */
 export function intervalToText({ interval, ends = "closed" }: Interval, arg: string = "x"): string {
   const left = Number.isFinite(interval[0])
     ? `${interval[0]} ${ends === "closed" || ends === "right-open" ? "<=" : "<"} `

--- a/packages/envisim-utils/tests/interval.test.ts
+++ b/packages/envisim-utils/tests/interval.test.ts
@@ -1,20 +1,67 @@
 import { expect, test } from "vitest";
-import { inInterval } from "../src/interval";
+import { inInterval, inUnitInterval, isLeftOfInterval, isRightOfInterval } from "../src/interval";
 
 test("inInterval", () => {
-  expect(inInterval(-1.0, { interval: [-1, 1], ends: "closed" })).toBeTruthy();
-  expect(inInterval(0.0, { interval: [-1, 1], ends: "closed" })).toBeTruthy();
-  expect(inInterval(1.0, { interval: [-1, 1], ends: "closed" })).toBeTruthy();
-  expect(inInterval(-1.0, { interval: [-1, 1], ends: "open" })).toBeFalsy();
-  expect(inInterval(0.0, { interval: [-1, 1], ends: "open" })).toBeTruthy();
-  expect(inInterval(1.0, { interval: [-1, 1], ends: "open" })).toBeFalsy();
-  expect(inInterval(-1.0, { interval: [-1, 1], ends: "left-open" })).toBeFalsy();
-  expect(inInterval(0.0, { interval: [-1, 1], ends: "left-open" })).toBeTruthy();
-  expect(inInterval(1.0, { interval: [-1, 1], ends: "left-open" })).toBeTruthy();
-  expect(inInterval(-1.0, { interval: [-1, 1], ends: "right-open" })).toBeTruthy();
-  expect(inInterval(0.0, { interval: [-1, 1], ends: "right-open" })).toBeTruthy();
-  expect(inInterval(1.0, { interval: [-1, 1], ends: "right-open" })).toBeFalsy();
-  expect(inInterval(1.0, { interval: [-1], ends: "right-open" })).toBeTruthy();
-  expect(inInterval(-Infinity, { interval: [-1, 1], ends: "right-open" })).toBeFalsy();
-  expect(inInterval(Infinity, { interval: [-1, 1], ends: "right-open" })).toBeFalsy();
+  expect(inInterval(-1.0, { interval: [-1, 1], ends: "closed" })).toBe(true);
+  expect(inInterval(0.0, { interval: [-1, 1], ends: "closed" })).toBe(true);
+  expect(inInterval(1.0, { interval: [-1, 1], ends: "closed" })).toBe(true);
+  expect(inInterval(-1.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(inInterval(0.0, { interval: [-1, 1], ends: "open" })).toBe(true);
+  expect(inInterval(1.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(inInterval(-1.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(inInterval(0.0, { interval: [-1, 1], ends: "left-open" })).toBe(true);
+  expect(inInterval(1.0, { interval: [-1, 1], ends: "left-open" })).toBe(true);
+  expect(inInterval(-1.0, { interval: [-1, 1], ends: "right-open" })).toBe(true);
+  expect(inInterval(0.0, { interval: [-1, 1], ends: "right-open" })).toBe(true);
+  expect(inInterval(1.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(inInterval(1.0, { interval: [-1], ends: "right-open" })).toBe(true);
+  expect(inInterval(-Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(inInterval(Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+});
+
+test("isLeftOfInterval", () => {
+  expect(isLeftOfInterval(-1.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isLeftOfInterval(0.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isLeftOfInterval(1.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isLeftOfInterval(-1.0, { interval: [-1, 1], ends: "open" })).toBe(true);
+  expect(isLeftOfInterval(0.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(isLeftOfInterval(1.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(isLeftOfInterval(-1.0, { interval: [-1, 1], ends: "left-open" })).toBe(true);
+  expect(isLeftOfInterval(0.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(isLeftOfInterval(1.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(isLeftOfInterval(-1.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isLeftOfInterval(0.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isLeftOfInterval(1.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isLeftOfInterval(1.0, { interval: [-1], ends: "right-open" })).toBe(false);
+  expect(isLeftOfInterval(-Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(true);
+  expect(isLeftOfInterval(Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+});
+
+test("isRightOfInterval", () => {
+  expect(isRightOfInterval(-1.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isRightOfInterval(0.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isRightOfInterval(1.0, { interval: [-1, 1], ends: "closed" })).toBe(false);
+  expect(isRightOfInterval(-1.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(isRightOfInterval(0.0, { interval: [-1, 1], ends: "open" })).toBe(false);
+  expect(isRightOfInterval(1.0, { interval: [-1, 1], ends: "open" })).toBe(true);
+  expect(isRightOfInterval(-1.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(isRightOfInterval(0.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(isRightOfInterval(1.0, { interval: [-1, 1], ends: "left-open" })).toBe(false);
+  expect(isRightOfInterval(-1.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isRightOfInterval(0.0, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isRightOfInterval(1.0, { interval: [-1, 1], ends: "right-open" })).toBe(true);
+  expect(isRightOfInterval(1.0, { interval: [-1], ends: "right-open" })).toBe(false);
+  expect(isRightOfInterval(-Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(false);
+  expect(isRightOfInterval(Infinity, { interval: [-1, 1], ends: "right-open" })).toBe(true);
+});
+
+test("inUnitInterval", () => {
+  expect(inUnitInterval(0.0, { ends: "closed" })).toBe(true);
+  expect(inUnitInterval(1.0, { ends: "closed" })).toBe(true);
+  expect(inUnitInterval(0.0, { ends: "open" })).toBe(false);
+  expect(inUnitInterval(1.0, { ends: "open" })).toBe(false);
+  expect(inUnitInterval(0.0, { ends: "left-open" })).toBe(false);
+  expect(inUnitInterval(1.0, { ends: "left-open" })).toBe(true);
+  expect(inUnitInterval(0.0, { ends: "right-open" })).toBe(true);
+  expect(inUnitInterval(1.0, { ends: "right-open" })).toBe(false);
 });


### PR DESCRIPTION
Removes the class Intervals, used in /distributions for support of distribution. Rely instead on functions on the Interval interface in /utils.

Added isLeftOfInterval, isRightOfInterval to utils